### PR TITLE
Allow all unfree packages globally

### DIFF
--- a/1password.nix
+++ b/1password.nix
@@ -2,10 +2,6 @@
 
 let onePassPath = "~/.1password/agent.sock";
 in {
-  # Enable the unfree 1Password packages
-  nixpkgs.config.allowUnfreePredicate = pkg:
-    builtins.elem (lib.getName pkg) [ "1password-gui" "1password" ];
-
   # Enable 1Password system-wide
   programs._1password.enable = true;
   programs._1password-gui = {

--- a/configuration.nix
+++ b/configuration.nix
@@ -2,6 +2,8 @@
 
 {
   nixpkgs.config.allowUnfree = true;
+  # Allow any unfree package globally
+  nixpkgs.config.allowUnfreePredicate = _: true;
   imports = [
     ./hardware-configuration.nix
     ./keyboard.nix


### PR DESCRIPTION
## Summary
- remove unfree predicate from `1password.nix`
- define a global `allowUnfreePredicate` in `configuration.nix`

## Testing
- `nix flake check --print-build-logs` *(failed: `nix` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf157b0e08329abdf6061e00f3fec