### PR TITLE
Switch to latest Linux kernel

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -20,7 +20,7 @@ in {
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
   boot.loader.systemd-boot.configurationLimit = 20;
-  boot.kernelPackages = pkgs.linuxPackages;
+  boot.kernelPackages = pkgs.linuxPackages_latest;
   # Unlock swap partition for hibernation
   boot.initrd.luks.devices."luks-727a76aa-c0e8-4aad-9176-79c292ff5ad7".device =
     "/dev/disk/by-uuid/727a76aa-c0e8-4aad-9176-79c292ff5ad7";


### PR DESCRIPTION
## Summary
- set the system configuration to use the latest Linux kernel package set via the `latest` modifier

## Testing
- nix flake check *(fails: `nix` command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937848274c483299757ab8842944e39)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * System boot configuration updated to use the latest available kernel packages, enhancing system compatibility and driver support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->